### PR TITLE
FIX [DA022744] : Pas d'interprétation de l'HTML

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## RELEASE 1.2
+- FIX : Interprétation de l'html dans les message à envoyer + Ajout de la clé de substitution __THIRDPARTY_name *22/03/2023* - 1.2.5
 - FIX : compat v17 *19/01/2023* - 1.2.4
 - FIX : Missing icon  *31/09/2022* - 1.2.3
 - FIX : Compatibility V16 : newToken and family - *23/06/2022* - 1.2.2

--- a/admin/propalautosend_setup.php
+++ b/admin/propalautosend_setup.php
@@ -52,7 +52,7 @@ $action = GETPOST('action', 'alpha');
 if (preg_match('/set_(.*)/',$action,$reg))
 {
 	$code=$reg[1];
-	if (dolibarr_set_const($db, $code, GETPOST($code,'alphanohtml'), 'chaine', 0, '', $conf->entity) > 0)
+	if (dolibarr_set_const($db, $code, GETPOST($code,'html'), 'chaine', 0, '', $conf->entity) > 0)
 	{
 		header("Location: ".$_SERVER["PHP_SELF"]);
 		exit;

--- a/class/propalautosendCron.class.php
+++ b/class/propalautosendCron.class.php
@@ -63,7 +63,8 @@ class propalautosendCron
 						'__PROPAL_total_tva' => $propal->total_tva,
 						'__PROPAL_total_ttc' => $propal->total_ttc,
 						'__PROPAL_datep' => dol_print_date($propal->datep, '%d/%m/%Y'),
-						'__PROPAL_fin_validite' => dol_print_date($propal->fin_validite, '%d/%m/%Y')
+						'__PROPAL_fin_validite' => dol_print_date($propal->fin_validite, '%d/%m/%Y'),
+						'__THIRDPARTY_name' => $propal->thirdparty->name
 				);
 				
 				foreach ($arraySubstitutions as $substit => $propalValue)

--- a/core/modules/modPropalautosend.class.php
+++ b/core/modules/modPropalautosend.class.php
@@ -61,7 +61,7 @@ class modPropalautosend extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module propalAutoSend";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.2.3';
+		$this->version = '1.2.5';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
## FIX [DA022744] : Pas d'interprétation de l'HTML

- Interprétation de l'html dans les message à envoyer
- Ajout de la clé de substitution __THIRDPARTY_name